### PR TITLE
Exclude guest logins from chart_logins

### DIFF
--- a/classes/chart_logins.php
+++ b/classes/chart_logins.php
@@ -84,8 +84,11 @@ class report_overviewstats_chart_logins extends report_overviewstats_chart {
             $logmanger = get_log_manager();
             $readers = $logmanger->get_readers('\core\log\sql_select_reader');
             $reader = reset($readers);
-            $params = array('component' => 'core', 'eventname' => '\core\event\user_loggedin', 'timestart' => $now - 30 * DAYSECS);
-            $select = "component = :component AND eventname = :eventname AND timecreated >= :timestart";
+            $params = array('component' => 'core',
+                            'eventname' => '\core\event\user_loggedin',
+                            'guestid' => $CFG->siteguest,
+                            'timestart' => $now - 30 * DAYSECS);
+            $select = "component = :component AND eventname = :eventname AND userid <> :guestid AND timecreated >= :timestart";
             $rs = $reader->get_events_select($select, $params, 'timecreated DESC', 0, 0);
 
             foreach ($rs as $record) {


### PR DESCRIPTION
This excludes guest from chart_logins to prevent large volumes of data causing an error. See MDLSITE-3683