### PR TITLE
Fix deprecated library include

### DIFF
--- a/classes/chart_courses.php
+++ b/classes/chart_courses.php
@@ -23,8 +23,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir.'/coursecatlib.php');
-
 /**
  * Reports various users related charts and figures
  */
@@ -100,12 +98,12 @@ class report_overviewstats_chart_courses extends report_overviewstats_chart {
 
         // Number of courses per category
 
-        $cats = coursecat::make_categories_list();
+        $cats = core_course_category::make_categories_list();
         $this->data['percategory'] = array();
         $total = 0;
 
         foreach ($cats as $catid => $catname) {
-            $cat = coursecat::get($catid);
+            $cat = core_course_category::get($catid);
             $coursesown = $cat->get_courses_count();
             $total += $coursesown;
             $this->data['percategory'][] = array(


### PR DESCRIPTION
References https://github.com/mudrd8mz/moodle-report_overviewstats/issues/10.

According to Moodle 3.9 Documentation:

```
debugging('Class coursecat is now alias to autoloaded class core_course_category, ' .
    'course_in_list is an alias to core_course_list_element. '.
    'Class coursecat_sortable_records is deprecated without replacement. Do not include coursecatlib.php',
    DEBUG_DEVELOPER);
```

This PR removes the include to coursecatlib.php which no longer exists in v3.10, and updates the calls in accordance with the message.